### PR TITLE
[Feature] Add support to render extra props (page number dependent) in the page buttons.

### DIFF
--- a/coverage/cobertura-coverage.xml
+++ b/coverage/cobertura-coverage.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?>
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
-<coverage lines-valid="62" lines-covered="56" line-rate="0.9031999999999999" branches-valid="48" branches-covered="32" branch-rate="0.6667000000000001" timestamp="1704996171722" complexity="0" version="0.1">
+<coverage lines-valid="63" lines-covered="57" line-rate="0.9048" branches-valid="50" branches-covered="34" branch-rate="0.68" timestamp="1714452817620" complexity="0" version="0.1">
   <sources>
-    <source>/Users/thijssmudde/projects/react-headless-pagination</source>
+    <source>/Users/a.matin/Development/devlab/react-headless-pagination</source>
   </sources>
   <packages>
-    <class name="Pagination.tsx" filename="src/Pagination/Pagination.tsx" line-rate="0.9031999999999999" branch-rate="0.6667000000000001">
+    <class name="Pagination.tsx" filename="src/Pagination/Pagination.tsx" line-rate="0.9048" branch-rate="0.68">
       <methods>
-        <method name="(anonymous_0)" hits="8" signature="()V">
+        <method name="(anonymous_0)" hits="9" signature="()V">
           <lines>
-            <line number="11" hits="8"/>
+            <line number="11" hits="9"/>
           </lines>
         </method>
         <method name="(anonymous_1)" hits="1" signature="()V">
@@ -27,9 +27,9 @@
             <line number="36" hits="0"/>
           </lines>
         </method>
-        <method name="(anonymous_4)" hits="8" signature="()V">
+        <method name="(anonymous_4)" hits="9" signature="()V">
           <lines>
-            <line number="48" hits="8"/>
+            <line number="48" hits="9"/>
           </lines>
         </method>
         <method name="(anonymous_5)" hits="1" signature="()V">
@@ -47,39 +47,39 @@
             <line number="73" hits="0"/>
           </lines>
         </method>
-        <method name="(anonymous_8)" hits="16" signature="()V">
+        <method name="(anonymous_8)" hits="18" signature="()V">
           <lines>
-            <line number="89" hits="16"/>
+            <line number="89" hits="18"/>
           </lines>
         </method>
-        <method name="(anonymous_9)" hits="8" signature="()V">
+        <method name="(anonymous_9)" hits="9" signature="()V">
           <lines>
-            <line number="105" hits="8"/>
+            <line number="105" hits="9"/>
           </lines>
         </method>
-        <method name="(anonymous_10)" hits="52" signature="()V">
+        <method name="(anonymous_10)" hits="59" signature="()V">
           <lines>
-            <line number="115" hits="52"/>
+            <line number="116" hits="59"/>
           </lines>
         </method>
         <method name="(anonymous_11)" hits="1" signature="()V">
           <lines>
-            <line number="127" hits="1"/>
+            <line number="128" hits="1"/>
           </lines>
         </method>
         <method name="(anonymous_12)" hits="1" signature="()V">
           <lines>
-            <line number="132" hits="1"/>
+            <line number="133" hits="1"/>
           </lines>
         </method>
         <method name="(anonymous_13)" hits="0" signature="()V">
           <lines>
-            <line number="159" hits="0"/>
+            <line number="161" hits="0"/>
           </lines>
         </method>
-        <method name="(anonymous_14)" hits="8" signature="()V">
+        <method name="(anonymous_14)" hits="9" signature="()V">
           <lines>
-            <line number="175" hits="8"/>
+            <line number="177" hits="9"/>
           </lines>
         </method>
       </methods>
@@ -88,64 +88,65 @@
         <line number="2" hits="1" branch="false"/>
         <line number="3" hits="1" branch="false"/>
         <line number="11" hits="1" branch="false"/>
-        <line number="12" hits="8" branch="false"/>
-        <line number="13" hits="8" branch="false"/>
-        <line number="14" hits="8" branch="false"/>
-        <line number="15" hits="8" branch="true" condition-coverage="50% (1/2)"/>
-        <line number="16" hits="8" branch="false"/>
-        <line number="18" hits="8" branch="false"/>
-        <line number="19" hits="8" branch="false"/>
+        <line number="12" hits="9" branch="false"/>
+        <line number="13" hits="9" branch="false"/>
+        <line number="14" hits="9" branch="false"/>
+        <line number="15" hits="9" branch="true" condition-coverage="50% (1/2)"/>
+        <line number="16" hits="9" branch="false"/>
+        <line number="18" hits="9" branch="false"/>
+        <line number="19" hits="9" branch="false"/>
         <line number="20" hits="1" branch="true" condition-coverage="50% (1/2)"/>
         <line number="21" hits="1" branch="false"/>
-        <line number="25" hits="8" branch="false"/>
-        <line number="27" hits="8" branch="false"/>
+        <line number="25" hits="9" branch="false"/>
+        <line number="27" hits="9" branch="false"/>
         <line number="32" hits="1" branch="false"/>
         <line number="37" hits="0" branch="false"/>
         <line number="38" hits="0" branch="true" condition-coverage="0% (0/4)"/>
         <line number="39" hits="0" branch="false"/>
         <line number="48" hits="1" branch="false"/>
-        <line number="49" hits="8" branch="false"/>
-        <line number="50" hits="8" branch="false"/>
-        <line number="51" hits="8" branch="false"/>
-        <line number="52" hits="8" branch="true" condition-coverage="50% (1/2)"/>
-        <line number="53" hits="8" branch="false"/>
-        <line number="55" hits="8" branch="false"/>
-        <line number="56" hits="8" branch="false"/>
+        <line number="49" hits="9" branch="false"/>
+        <line number="50" hits="9" branch="false"/>
+        <line number="51" hits="9" branch="false"/>
+        <line number="52" hits="9" branch="true" condition-coverage="50% (1/2)"/>
+        <line number="53" hits="9" branch="false"/>
+        <line number="55" hits="9" branch="false"/>
+        <line number="56" hits="9" branch="false"/>
         <line number="57" hits="1" branch="true" condition-coverage="50% (1/2)"/>
         <line number="58" hits="1" branch="false"/>
-        <line number="62" hits="8" branch="false"/>
-        <line number="64" hits="8" branch="false"/>
+        <line number="62" hits="9" branch="false"/>
+        <line number="64" hits="9" branch="false"/>
         <line number="69" hits="1" branch="false"/>
         <line number="74" hits="0" branch="false"/>
         <line number="75" hits="0" branch="true" condition-coverage="0% (0/4)"/>
         <line number="76" hits="0" branch="false"/>
-        <line number="89" hits="16" branch="false"/>
-        <line number="90" hits="16" branch="false"/>
-        <line number="97" hits="64" branch="false"/>
-        <line number="99" hits="16" branch="true" condition-coverage="100% (4/4)"/>
+        <line number="89" hits="18" branch="false"/>
+        <line number="90" hits="18" branch="false"/>
+        <line number="97" hits="72" branch="false"/>
+        <line number="99" hits="18" branch="true" condition-coverage="100% (4/4)"/>
         <line number="105" hits="1" branch="false"/>
-        <line number="106" hits="8" branch="true" condition-coverage="100% (2/2)"/>
-        <line number="107" hits="8" branch="false"/>
-        <line number="108" hits="8" branch="false"/>
-        <line number="109" hits="8" branch="false"/>
-        <line number="110" hits="8" branch="false"/>
-        <line number="111" hits="8" branch="false"/>
-        <line number="113" hits="8" branch="false"/>
-        <line number="115" hits="52" branch="false"/>
-        <line number="128" hits="1" branch="true" condition-coverage="50% (1/2)"/>
-        <line number="129" hits="1" branch="false"/>
-        <line number="132" hits="1" branch="false"/>
-        <line number="146" hits="8" branch="false"/>
-        <line number="157" hits="1" branch="false"/>
-        <line number="173" hits="1" branch="false"/>
+        <line number="106" hits="9" branch="true" condition-coverage="100% (2/2)"/>
+        <line number="107" hits="9" branch="false"/>
+        <line number="108" hits="9" branch="false"/>
+        <line number="109" hits="9" branch="false"/>
+        <line number="110" hits="9" branch="false"/>
+        <line number="111" hits="9" branch="false"/>
+        <line number="112" hits="9" branch="false"/>
+        <line number="114" hits="9" branch="false"/>
+        <line number="116" hits="59" branch="false"/>
+        <line number="129" hits="1" branch="true" condition-coverage="50% (1/2)"/>
+        <line number="130" hits="1" branch="false"/>
+        <line number="133" hits="1" branch="false"/>
+        <line number="148" hits="9" branch="false"/>
+        <line number="159" hits="1" branch="false"/>
         <line number="175" hits="1" branch="false"/>
-        <line number="176" hits="8" branch="false"/>
-        <line number="177" hits="8" branch="false"/>
-        <line number="179" hits="8" branch="false"/>
-        <line number="181" hits="8" branch="false"/>
-        <line number="190" hits="1" branch="false"/>
-        <line number="191" hits="1" branch="false"/>
+        <line number="177" hits="1" branch="false"/>
+        <line number="178" hits="9" branch="false"/>
+        <line number="179" hits="9" branch="false"/>
+        <line number="181" hits="9" branch="false"/>
+        <line number="183" hits="9" branch="false"/>
         <line number="192" hits="1" branch="false"/>
+        <line number="193" hits="1" branch="false"/>
+        <line number="194" hits="1" branch="false"/>
       </lines>
     </class>
   </packages>

--- a/src/Pagination/Pagination.test.tsx
+++ b/src/Pagination/Pagination.test.tsx
@@ -121,6 +121,33 @@ describe("Pagination", () => {
     expect(headingElement.tagName.toLowerCase()).toEqual("span");
   });
 
+  it("renders correctly with extra page button props", () => {
+    const { asFragment } = setupPagination({
+      children: (
+        <>
+          <Pagination.PrevButton>Previous</Pagination.PrevButton>
+
+          <div className="flex items-center justify-center flex-grow">
+            <Pagination.PageButton
+              as={<span />}
+              dataTestIdActive="page-button-extra-props"
+              renderExtraProps={(page) => ({
+                "aria-label": `Go to page ${page}`,
+              })}
+            />
+          </div>
+
+          <Pagination.NextButton>Next</Pagination.NextButton>
+        </>
+      ),
+    });
+
+    expect(asFragment()).toMatchSnapshot();
+
+    const pageBtnElem = screen.getByTestId("page-button-extra-props");
+    expect(pageBtnElem.getAttribute("aria-label")).toContain("Go to page");
+  });
+
   it("clicking on previous calls mockSetCurrentPage with currentPage - 1", () => {
     const mockSetCurrentPage = jest.fn();
 

--- a/src/Pagination/Pagination.test.tsx.snap
+++ b/src/Pagination/Pagination.test.tsx.snap
@@ -432,3 +432,104 @@ exports[`Pagination renders correctly with different truncable text 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`Pagination renders correctly with extra page button props 1`] = `
+<DocumentFragment>
+  <div
+    class=""
+  >
+    <button
+      class=""
+      tabindex="0"
+    >
+      Previous
+    </button>
+    <div
+      class="flex items-center justify-center flex-grow"
+    >
+      <li>
+        <span
+          aria-label="Go to page 1"
+          class=""
+          data-testid="undefined-1"
+          tabindex="0"
+        >
+          1
+        </span>
+      </li>
+      <li>
+        ...
+      </li>
+      <li>
+        <span
+          aria-label="Go to page 4"
+          class=""
+          data-testid="undefined-4"
+          tabindex="0"
+        >
+          4
+        </span>
+      </li>
+      <li>
+        <span
+          aria-label="Go to page 5"
+          class=""
+          data-testid="undefined-5"
+          tabindex="0"
+        >
+          5
+        </span>
+      </li>
+      <li>
+        <span
+          aria-label="Go to page 6"
+          class=""
+          data-testid="page-button-extra-props"
+          tabindex="0"
+        >
+          6
+        </span>
+      </li>
+      <li>
+        <span
+          aria-label="Go to page 7"
+          class=""
+          data-testid="undefined-7"
+          tabindex="0"
+        >
+          7
+        </span>
+      </li>
+      <li>
+        <span
+          aria-label="Go to page 8"
+          class=""
+          data-testid="undefined-8"
+          tabindex="0"
+        >
+          8
+        </span>
+      </li>
+      <li>
+        ...
+      </li>
+      <li>
+        <span
+          aria-label="Go to page 10"
+          class=""
+          data-testid="undefined-10"
+          tabindex="0"
+        >
+          10
+        </span>
+      </li>
+    </div>
+    <button
+      class=""
+      tabindex="0"
+    >
+      Next
+    </button>
+  </div>
+</DocumentFragment>
+`;

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -98,8 +98,8 @@ const TruncableElement = ({ prev }: ITruncableElementProps) => {
 
   return (isPreviousTruncable && prev === true) ||
     (isNextTruncable && !prev) ? (
-      <li className={truncableClassName || undefined}>{truncableText}</li>
-    ) : null;
+    <li className={truncableClassName || undefined}>{truncableText}</li>
+  ) : null;
 };
 
 export const PageButton = ({
@@ -109,6 +109,7 @@ export const PageButton = ({
   dataTestIdInactive,
   activeClassName,
   inactiveClassName,
+  renderExtraProps,
 }: PageButtonProps) => {
   const pagination: IPagination = React.useContext(PaginationContext);
 
@@ -137,6 +138,7 @@ export const PageButton = ({
             : inactiveClassName,
         )}
         {...as.props}
+        {...(renderExtraProps ? renderExtraProps(page) : {})}
       >
         {page}
       </as.type>
@@ -156,7 +158,7 @@ export const PageButton = ({
 
 const defaultState: IPagination = {
   currentPage: 0,
-  setCurrentPage: () => { },
+  setCurrentPage: () => {},
   truncableText: "...",
   truncableClassName: "",
   pages: [],

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -46,6 +46,7 @@ type PageButtonProps = ButtonProps & {
   inactiveClassName?: string;
   dataTestIdActive?: string;
   dataTestIdInactive?: string;
+  renderExtraProps?: (pageNum: number) => {};
 };
 
 export {

--- a/stories/PaginationWithExtraProps.stories.tsx
+++ b/stories/PaginationWithExtraProps.stories.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Meta, Story } from "@storybook/react";
+import { Pagination, IPaginationProps } from "../src";
+
+const meta: Meta = {
+  title: "Pagination With Extra Page Button Props",
+  component: Pagination,
+  parameters: {
+    controls: { expanded: true },
+  },
+};
+
+export default meta;
+
+const PaginationWithExtraPropsStory: Story<IPaginationProps> = (args) => {
+  const [page, setPage] = React.useState<number>(0);
+
+  const handlePageChange = (page: number) => {
+    setPage(page);
+  };
+
+  return (
+    <>
+      Current page: {page + 1}
+      <Pagination
+        {...args}
+        currentPage={page}
+        setCurrentPage={handlePageChange}
+        className=""
+        truncableText="..."
+        truncableClassName=""
+      >
+        <Pagination.PrevButton className="">Previous</Pagination.PrevButton>
+
+        <nav className="flex justify-center flex-grow">
+          <ul className="flex items-center">
+            <Pagination.PageButton
+              activeClassName=""
+              inactiveClassName=""
+              className=""
+              renderExtraProps={(page) => ({
+                "aria-label": `Go to page - ${page}`,
+              })}
+            />
+          </ul>
+        </nav>
+
+        <Pagination.NextButton className="">Next</Pagination.NextButton>
+      </Pagination>
+    </>
+  );
+};
+
+export const Default = PaginationWithExtraPropsStory.bind({});
+
+Default.args = {
+  totalPages: 10,
+  edgePageCount: 2,
+  middlePagesSiblingCount: 1,
+  truncableText: "...",
+  truncableClassName: "",
+};


### PR DESCRIPTION
#15 

Why:

In one of our project we need to add `aria-label` in the page buttons where it will also need the page number. For example `aria-label="Go to page 3"`. That is why we need to the support to add/render extra props in the PageButtons.

What:

In the MR, add a new prop `renderExtraProps` in the PageButton Component. This optional prop is a function that will pass the current page number as a parameter and expect to get a object in return which will be spreaded in the PageButton component.
