### PR TITLE
Fix: correct edge page filtering

### DIFF
--- a/src/Hooks/usePagination.ts
+++ b/src/Hooks/usePagination.ts
@@ -42,9 +42,14 @@ const usePagination = ({
     if (isReachedToFirst || getAllPreviousPages().length < 1) {
       return [];
     }
-    return pages
-      .slice(0, edgePageCount)
-      .filter((p) => !middlePages.includes(p));
+
+    const leftEdgePages = pages.slice(0, edgePageCount);
+    const firstMiddlePage = middlePages[0];
+    const leftEdgePagesBeforeMiddle = leftEdgePages.filter(
+      (page) => page < firstMiddlePage,
+    );
+
+    return leftEdgePagesBeforeMiddle;
   }, [currentPage, pages]);
 
   const getAllNextPages = React.useMemo(() => {
@@ -61,9 +66,17 @@ const usePagination = ({
     if (getAllNextPages.length < 1) {
       return [];
     }
-    return pages
-      .slice(pages.length - edgePageCount, pages.length)
-      .filter((p) => !middlePages.includes(p));
+
+    const rightEdgePages = pages.slice(
+      pages.length - edgePageCount,
+      pages.length,
+    );
+    const lastMiddlePage = middlePages[middlePages.length - 1];
+    const rightEdgePagesAfterMiddle = rightEdgePages.filter(
+      (page) => page > lastMiddlePage,
+    );
+
+    return rightEdgePagesAfterMiddle;
   }, [middlePages, pages]);
 
   const isPreviousTruncable = React.useMemo(() => {


### PR DESCRIPTION
**Issue:**  
Edge pages are not filtered correctly, leading to non-sequential pagination when slicing out middle pages.

https://github.com/user-attachments/assets/5a076104-df98-4ee3-be0f-486b35eca5f9

**Cause:**  
The previous logic removed items from the middle of the array without considering sequential order.

**Fix:**  
- Filter left edge pages to only include pages before the first middle page.  
- Filter right edge pages to only include pages after the last middle page.  

**Testing:**  
- Verified pagination renders sequentially with parameters like:
```tsx
totalPages={10}
edgePageCount={6}
middlePagesSiblingCount={1}
```

Please review the changes.